### PR TITLE
Update credits

### DIFF
--- a/gameoffgame/scenes/intro/credits.tscn
+++ b/gameoffgame/scenes/intro/credits.tscn
@@ -96,7 +96,7 @@ Testing:                       Nahomy Mejia
 
 
 
-The Autors would also like to acknowledge the support of
+The Authors would also like to acknowledge the support of
 the Godot Engine Facebook community
 https://www.facebook.com/groups/godotengine
 


### PR DESCRIPTION
Noticed a lil' typo in the credits:

![12312312312](https://user-images.githubusercontent.com/121322/33914888-2f24d018-df55-11e7-98a9-4f247b35574b.gif)

This PR changes `AUTORS` to `AUTHORS`.
Or should it be Otters? 🤔  <img src="https://ksr-ugc.imgix.net/assets/002/181/067/d9358233f62bd5e9117d7658a718ab0e_original.gif?w=680&fit=max&v=1403493806&auto=format&gif-q=50&q=92&s=1e3e6e52fc0e8564dbbe833a5d886702" height="32">